### PR TITLE
Upgrade acturial/clickatell to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "illuminate/notifications": "~5.5 || ~6.0",
         "illuminate/support": "~5.5 || ~6.0",
-        "arcturial/clickatell": "~2.1"
+        "arcturial/clickatell": "~3.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.2",

--- a/src/ClickatellChannel.php
+++ b/src/ClickatellChannel.php
@@ -38,6 +38,10 @@ class ClickatellChannel
             $message = new ClickatellMessage($message);
         }
 
+        if (!is_array($to)) {
+            $to = [ $to ];
+        }
+
         $this->clickatell->send($to, $message->getContent());
     }
 }

--- a/src/ClickatellClient.php
+++ b/src/ClickatellClient.php
@@ -41,14 +41,14 @@ class ClickatellClient
     {
         $to = collect($to)->toArray();
 
-        try {
-            $response = $this->clickatell->sendMessage($to, $message);
-        } catch (ClickatellException $e) {
-            throw CouldNotSendNotification::serviceRespondedWithAnError(
-                (string) $e,
-                $errorCode
-            );
-        }
+        $client = new \GuzzleHttp\Client(['base_uri' => 'https://platform.clickatell.com/messages/http/']);
+        $query = sprintf(
+            'send?apiKey=%s&to=%s&content=%s',
+            config('services.clickatell.api_key'),
+            reset($to),
+            $message
+        );
+        $response = $client->request('GET', $query);
     }
 
     /**

--- a/src/ClickatellServiceProvider.php
+++ b/src/ClickatellServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Clickatell;
 
-use Clickatell\Api\ClickatellHttp;
+use Clickatell\Rest;
 use Illuminate\Support\ServiceProvider;
 
 class ClickatellServiceProvider extends ServiceProvider
@@ -18,10 +18,8 @@ class ClickatellServiceProvider extends ServiceProvider
                 $config = config('services.clickatell');
 
                 return new ClickatellClient(
-                    new ClickatellHttp(
-                        $config['user'],
-                        $config['pass'],
-                        $config['api_id']
+                    new Rest(
+                        $config['api_key']
                     )
                 );
             });


### PR DESCRIPTION
This upgrades acturial/clickatell composer package to allow us to
use the newer version of the API that only requires an api_key.

As a result, `config/services.php` clickatell entry must now contain
a `clickatell.api_key` field.

Error handling still needs to be implemented correctly.

As this is a breaking change, I'm unsure how you would like to handle it.